### PR TITLE
Use date-fns setWeek() for robust week calculations

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Calendar from 'react-calendar';
-import { getWeek, getYear, startOfWeek, endOfWeek, format } from 'date-fns';
+import { getWeek, getYear, startOfWeek, endOfWeek, format, setWeek } from 'date-fns';
 import 'react-calendar/dist/Calendar.css';
 import { 
   Container, 
@@ -68,8 +68,8 @@ function App() {
   };
 
   const updateDates = (week, yearNum) => {
-    const firstDayOfWeek = startOfWeek(new Date(yearNum, 0, (week - 1) * 7 + 1), { weekStartsOn: 1 });
-    const lastDayOfWeek = endOfWeek(new Date(firstDayOfWeek.getTime() + 6 * 24 * 60 * 60 * 1000), { weekStartsOn: 1 });
+    const firstDayOfWeek = startOfWeek(setWeek(new Date(yearNum, 0, 1), week, { weekStartsOn: 1 }), { weekStartsOn: 1 });
+    const lastDayOfWeek = endOfWeek(firstDayOfWeek, { weekStartsOn: 1 });
 
     setStartDate(format(firstDayOfWeek, 'MMM dd, yyyy'));
     setEndDate(format(lastDayOfWeek, 'MMM dd, yyyy'));
@@ -87,7 +87,7 @@ function App() {
     }
     setWeekNumber(newWeekNumber);
     updateDates(newWeekNumber, year);
-    setDate(new Date(year, 0, (newWeekNumber - 1) * 7 + 1));
+    setDate(setWeek(new Date(year, 0, 1), newWeekNumber, { weekStartsOn: 1 }));
   };
 
   // Manages changes to the year input
@@ -102,7 +102,7 @@ function App() {
     }
     setYear(newYear);
     updateDates(weekNumber, newYear);
-    setDate(new Date(newYear, 0, (weekNumber - 1) * 7 + 1));
+    setDate(setWeek(new Date(newYear, 0, 1), weekNumber, { weekStartsOn: 1 }));
   };  
   
   return (

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,165 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { format, setWeek, startOfWeek, endOfWeek } from 'date-fns';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+// Helper function to get week calculation results like the app does
+const calculateWeekDates = (week, year) => {
+  const firstDayOfWeek = startOfWeek(setWeek(new Date(year, 0, 1), week, { weekStartsOn: 1 }), { weekStartsOn: 1 });
+  const lastDayOfWeek = endOfWeek(firstDayOfWeek, { weekStartsOn: 1 });
+  return {
+    start: format(firstDayOfWeek, 'MMM dd, yyyy'),
+    end: format(lastDayOfWeek, 'MMM dd, yyyy')
+  };
+};
+
+describe('Calendar Week Application', () => {
+  test('renders week calendar application', () => {
+    render(<App />);
+    expect(screen.getByText(/Calendar Week Navigator/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Week Number/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Year/i)).toBeInTheDocument();
+  });
+
+  test('displays current week and year on initial render', () => {
+    render(<App />);
+    
+    // Check that week number and year inputs have initial values
+    const weekInput = screen.getByLabelText(/Week Number/i);
+    const yearInput = screen.getByLabelText(/Year/i);
+    
+    expect(weekInput.value).toBeTruthy();
+    expect(yearInput.value).toBeTruthy();
+    expect(parseInt(yearInput.value)).toBeGreaterThanOrEqual(2024);
+  });
+
+  test('calculates correct dates for week 1 of 2024', async () => {
+    render(<App />);
+    
+    const weekInput = screen.getByLabelText(/Week Number/i);
+    const yearInput = screen.getByLabelText(/Year/i);
+    
+    // Set to week 1, 2024
+    fireEvent.change(yearInput, { target: { value: '2024' } });
+    fireEvent.change(weekInput, { target: { value: '1' } });
+    
+    await waitFor(() => {
+      const expectedDates = calculateWeekDates(1, 2024);
+      expect(screen.getByText(expectedDates.start)).toBeInTheDocument();
+      expect(screen.getByText(expectedDates.end)).toBeInTheDocument();
+    });
+  });
+
+  test('calculates correct dates for week 53 of 2020 (leap year with 53 weeks)', async () => {
+    render(<App />);
+    
+    const weekInput = screen.getByLabelText(/Week Number/i);
+    const yearInput = screen.getByLabelText(/Year/i);
+    
+    // Set to week 53, 2020 (2020 was a leap year with 53 weeks)
+    fireEvent.change(yearInput, { target: { value: '2020' } });
+    fireEvent.change(weekInput, { target: { value: '53' } });
+    
+    await waitFor(() => {
+      const expectedDates = calculateWeekDates(53, 2020);
+      expect(screen.getByText(expectedDates.start)).toBeInTheDocument();
+      expect(screen.getByText(expectedDates.end)).toBeInTheDocument();
+    });
+  });
+
+  test('calculates correct dates for week 26 of 2023 (mid-year)', async () => {
+    render(<App />);
+    
+    const weekInput = screen.getByLabelText(/Week Number/i);
+    const yearInput = screen.getByLabelText(/Year/i);
+    
+    // Set to week 26, 2023 (approximately mid-year)
+    fireEvent.change(yearInput, { target: { value: '2023' } });
+    fireEvent.change(weekInput, { target: { value: '26' } });
+    
+    await waitFor(() => {
+      const expectedDates = calculateWeekDates(26, 2023);
+      expect(screen.getByText(expectedDates.start)).toBeInTheDocument();
+      expect(screen.getByText(expectedDates.end)).toBeInTheDocument();
+    });
+  });
+
+  test('handles invalid week number input', async () => {
+    render(<App />);
+    
+    const weekInput = screen.getByLabelText(/Week Number/i);
+    
+    // Test invalid week numbers
+    fireEvent.change(weekInput, { target: { value: '0' } });
+    expect(weekInput.value).toBe('');
+    
+    fireEvent.change(weekInput, { target: { value: '54' } });
+    expect(weekInput.value).toBe('');
+    
+    fireEvent.change(weekInput, { target: { value: '-1' } });
+    expect(weekInput.value).toBe('');
+  });
+
+  test('handles invalid year input', async () => {
+    render(<App />);
+    
+    const yearInput = screen.getByLabelText(/Year/i);
+    
+    // Test invalid years
+    fireEvent.change(yearInput, { target: { value: '0' } });
+    expect(yearInput.value).toBe('');
+    
+    fireEvent.change(yearInput, { target: { value: '10000' } });
+    expect(yearInput.value).toBe('');
+    
+    fireEvent.change(yearInput, { target: { value: '-1' } });
+    expect(yearInput.value).toBe('');
+  });
+
+  test('week calculation edge case: new year week transition', async () => {
+    render(<App />);
+    
+    const weekInput = screen.getByLabelText(/Week Number/i);
+    const yearInput = screen.getByLabelText(/Year/i);
+    
+    // Test week 1 of various years to ensure proper year boundary handling
+    const testYears = [2021, 2022, 2023, 2024, 2025];
+    
+    for (const year of testYears) {
+      fireEvent.change(yearInput, { target: { value: year.toString() } });
+      fireEvent.change(weekInput, { target: { value: '1' } });
+      
+      await waitFor(() => {
+        const expectedDates = calculateWeekDates(1, year);
+        expect(screen.getByText(expectedDates.start)).toBeInTheDocument();
+        expect(screen.getByText(expectedDates.end)).toBeInTheDocument();
+      });
+    }
+  });
+
+  test('week calculation consistency: same week different years', async () => {
+    render(<App />);
+    
+    const weekInput = screen.getByLabelText(/Week Number/i);
+    const yearInput = screen.getByLabelText(/Year/i);
+    
+    // Test that week 10 in different years produces consistent results
+    const testCases = [
+      { year: 2020, week: 10 },
+      { year: 2021, week: 10 },
+      { year: 2022, week: 10 },
+      { year: 2023, week: 10 },
+      { year: 2024, week: 10 }
+    ];
+    
+    for (const testCase of testCases) {
+      fireEvent.change(yearInput, { target: { value: testCase.year.toString() } });
+      fireEvent.change(weekInput, { target: { value: testCase.week.toString() } });
+      
+      await waitFor(() => {
+        const expectedDates = calculateWeekDates(testCase.week, testCase.year);
+        expect(screen.getByText(expectedDates.start)).toBeInTheDocument();
+        expect(screen.getByText(expectedDates.end)).toBeInTheDocument();
+      });
+    }
+  });
 });


### PR DESCRIPTION
Replace manual date calculation `(week - 1) * 7 + 1` with date-fns' setWeek() function for more reliable week handling across edge cases.

## Changes
- Import setWeek from date-fns
- Replace manual calculation in updateDates()
- Update handleWeekNumberChange() to use setWeek()
- Update handleYearChange() to use setWeek()
- Add comprehensive unit tests covering edge cases

Fixes #9

Generated with [Claude Code](https://claude.ai/code)